### PR TITLE
Remove orange highlight from Sekki header

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
                     </div>
                     <div id="nextSekkiInfo" class="text-sm text-gray-600"></div>
                     <!-- 今日の日付を大きく表示 -->
-                    <div class="mt-4 p-4 bg-amber-50 rounded-lg border-2 border-amber-400">
+                    <div class="mt-4">
                         <div class="text-sm text-gray-600" id="todayDateYear"></div>
                         <div class="text-3xl sm:text-4xl font-bold text-gray-800" id="todayDateFull"></div>
                         <div class="text-base text-gray-600" id="todayDateDay"></div>


### PR DESCRIPTION
## Summary
- remove the orange-bordered box beneath the seasonal (Sekki) title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aaee924c48330883feadffe73f3a1