### PR TITLE
Fix prev day button overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 </head>
 <body>
     <!-- スワイプメニュー -->
-    <div id="swipeMenu" class="fixed left-0 top-0 bottom-0 w-16 z-50">
+    <div id="swipeMenu" class="fixed left-0 top-0 bottom-0 w-8 z-50">
         <!-- メニューオープンエリア -->
         <div id="menuHandle" class="absolute left-0 top-1/2 transform -translate-y-1/2 w-8 h-32 cursor-pointer">
             <div class="w-full h-full bg-gradient-to-r from-gray-800 to-transparent opacity-30 rounded-r-full"></div>


### PR DESCRIPTION
## Summary
- narrow the left-side menu container so it doesn't cover the previous day button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685abe18f480833080bdfaf85c087957